### PR TITLE
Cap papers per issue and split into multiple issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ github:
   usernames:
     - "your-username" # Users to tag in the issue
   issue_label: "arxiv-summary"
+  max_papers_per_issue: 10 # Split into multiple issues when more papers are found
 
 llm_service:
   base_url: "https://models.github.ai/inference"

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ github:
   usernames:
     - "matouskozak"
   issue_label: "arxiv-summary"
+  max_papers_per_issue: 10
 
 llm_service:
   base_url: "https://models.github.ai/inference"

--- a/src/issue_creator.py
+++ b/src/issue_creator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from math import ceil
 from models import Paper, PaperSummary
 from utils import save_issue_to_tmp
 
@@ -10,40 +11,69 @@ def format_summary(summary):
     return str(summary)
 
 
-def create_issue(github_client, papers: list[Paper], usernames=None, issue_label="arxiv-summary", start_date=None, end_date=None):
+def _format_paper(paper: Paper) -> str:
+    body = f"## {paper.title}\n"
+    body += f"**Authors:** {', '.join(paper.authors)}\n\n"
+    body += f"### Summary\n{format_summary(paper.summary)}\n\n"
+    body += f"[View on ArXiv]({paper.link})\n\n"
+    body += f"- [ ] 📚 Read Later\n\n"
+    body += "---\n\n"
+    return body
+
+
+def create_issue(github_client, papers: list[Paper], usernames=None, issue_label="arxiv-summary", start_date=None, end_date=None, max_papers_per_issue: int = 10):
     if usernames is None:
         usernames = []
+
+    if not papers:
+        return
+
+    if max_papers_per_issue <= 0:
+        raise ValueError("max_papers_per_issue must be a positive integer")
 
     # Format Issue Title with time range
     date_str = datetime.now().strftime("%Y-%m-%d")
     if start_date and end_date:
         start_str = start_date.strftime("%Y-%m-%d")
         end_str = end_date.strftime("%Y-%m-%d")
-        title = f"ArXiv Summary - {date_str} (papers from {start_str} to {end_str})"
+        base_title = f"ArXiv Summary - {date_str} (papers from {start_str} to {end_str})"
     else:
-        title = f"ArXiv Summary - {date_str}"
-    
-    body = f"# ArXiv Paper Summaries ({date_str})\n\n"
-    body += f"Found {len(papers)} relevant papers.\n\n"
-    
-    for paper in papers:
-        body += f"## {paper.title}\n"
-        body += f"**Authors:** {', '.join(paper.authors)}\n\n"
-        body += f"### Summary\n{format_summary(paper.summary)}\n\n"
-        body += f"[View on ArXiv]({paper.link})\n\n"
-        body += f"- [ ] 📚 Read Later\n\n"
-        body += "---\n\n"
+        base_title = f"ArXiv Summary - {date_str}"
 
-    # Save issue to tmp folder before posting
-    save_issue_to_tmp(title, body)
+    total_papers = len(papers)
+    total_parts = ceil(total_papers / max_papers_per_issue)
 
-    # Create Issue via API
-    github_client.create_issue(
-        title=title,
-        body=body,
-        labels=[issue_label],
-        assignees=usernames if usernames else None
-    )
+    for part_idx in range(total_parts):
+        start = part_idx * max_papers_per_issue
+        end = min(start + max_papers_per_issue, total_papers)
+        chunk = papers[start:end]
+
+        if total_parts > 1:
+            title = f"{base_title} (Part {part_idx + 1}/{total_parts})"
+            range_note = f"Papers {start + 1}-{end} of {total_papers} (Part {part_idx + 1}/{total_parts}).\n\n"
+            tmp_suffix = f"_part{part_idx + 1}of{total_parts}"
+        else:
+            title = base_title
+            range_note = ""
+            tmp_suffix = ""
+
+        body = f"# ArXiv Paper Summaries ({date_str})\n\n"
+        body += f"Found {total_papers} relevant papers.\n\n"
+        body += range_note
+
+        for paper in chunk:
+            body += _format_paper(paper)
+
+        # Save issue to tmp folder before posting
+        save_issue_to_tmp(title, body, suffix=tmp_suffix)
+
+        # Create Issue via API
+        github_client.create_issue(
+            title=title,
+            body=body,
+            labels=[issue_label],
+            assignees=usernames if usernames else None
+        )
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -37,6 +37,7 @@ def main():
     github_config = config["github"]
     usernames = github_config.get("usernames", [])
     issue_label = github_config.get("issue_label", "arxiv-summary")
+    max_papers_per_issue = github_config.get("max_papers_per_issue", 10)
     
     openai_base_url = config["llm_service"]["base_url"]
     api_key = config["llm_service"]["api_key"]
@@ -84,7 +85,7 @@ def main():
     # 4. Create Issue
     print("--- Step 4: Creating GitHub Issue ---")
     try:
-        create_issue(github_client, summarized_papers, usernames, issue_label, last_run, end_date)
+        create_issue(github_client, summarized_papers, usernames, issue_label, last_run, end_date, max_papers_per_issue=max_papers_per_issue)
     except RuntimeError as e:
         print(f"Error: {e}")
         exit(1)

--- a/src/utils.py
+++ b/src/utils.py
@@ -205,13 +205,13 @@ def save_summary_to_tmp(paper: dict, summary_text: str) -> Path | None:
     return file_path
 
 
-def save_issue_to_tmp(title: str, body: str) -> Path | None:
+def save_issue_to_tmp(title: str, body: str, suffix: str = "") -> Path | None:
     """Save the issue content to tmp folder before posting to GitHub (local only)."""
     if is_running_in_ci():
         return None
     
     timestamp = get_timestamp()
-    filename = f"{timestamp}_issue.md"
+    filename = f"{timestamp}_issue{suffix}.md"
     
     content = f"# {title}\n\n{body}"
     


### PR DESCRIPTION
## Summary

When the digest finds more papers than `max_papers_per_issue` (default **10**), create multiple GitHub issues with a `(Part i/N)` suffix in the title instead of producing one oversized issue. When all papers fit in a single issue, the title is unchanged.

## Changes

- **`config.yaml`** — add `github.max_papers_per_issue: 10`
- **`README.md`** — document the new config key
- **`src/issue_creator.py`** — `create_issue` chunks `papers` into batches of `max_papers_per_issue` and posts one issue per chunk; per-part body header notes `Papers X-Y of N`
- **`src/main.py`** — read the cap from config (default `10`) and pass it through
- **`src/utils.py`** — `save_issue_to_tmp` accepts an optional `suffix` so tmp files for each part don't collide

## Verification

Local dry-run with a fake GitHub client covered five scenarios — all assertions passed:

| Scenario | Result |
|---|---|
| 23 papers, cap 10 | 3 issues: `(Part 1/3)`, `(Part 2/3)`, `(Part 3/3)` |
| 10 papers, cap 10 | 1 issue, no `Part` suffix |
| 5 papers, cap 10 | 1 issue, no `Part` suffix |
| 0 papers | 0 issues created |
| 12 papers + date range | 2 issues, `(Part i/2)` appears after the date range |

## Notes

- Single-issue behavior (title and body) is byte-for-byte preserved when `len(papers) <= cap`.
- If a mid-batch `create_issue` call fails, earlier parts are already posted and `main.py` exits on `RuntimeError`; the next scheduled run picks up the remaining papers via `get_last_issue_date`'s 1-hour buffer.